### PR TITLE
Create Resource model and controller

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,7 +1,8 @@
 addReviewers: true
 addAssignees: false
 reviewers:
-  - jillh510
+  - egiurleo
+  - JZenk
   - dryan
 skipKeywords:
   - wip

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'puma', '~> 3.11'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'json'
+gem 'carmen'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
+    carmen (1.1.3)
+      activesupport (>= 3.0.0)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -158,6 +160,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
+  carmen
   factory_bot_rails
   json
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,0 +1,37 @@
+class ResourcesController < ApplicationController
+  before_action :find_resource, only: [:show, :update, :destroy]
+
+  def show
+    render json: @resource
+  end
+
+  def create
+    # TODO: authenticate admin user
+    @resource = Resource.create
+    render status: 201, json: @resource
+  end
+
+  def destroy
+    # TODO: authenticate admin user
+    @resource.destroy
+    render status: 204, json: {}
+  end
+
+  def update
+    # TODO: authenticate admin user
+    attributes = params.permit(upsert_params(Resource))
+    @resource.update!(attributes)
+
+    render json: @resource
+  end
+
+  private
+
+  def find_resource
+    begin
+      @resource = Resource.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render status: 404, json: {} and return
+    end
+  end
+end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -7,7 +7,13 @@ class ResourcesController < ApplicationController
 
   def create
     # TODO: authenticate admin user
-    @resource = Resource.create
+    @resource = Resource.new(resource_category_id: params[:resource_category_id], state: params[:state])
+
+    begin
+      @resource.save!
+    rescue ActiveRecord::RecordInvalid => e
+      render status: 400, json: { error: e.message } and return
+    end
     render status: 201, json: @resource
   end
 

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,5 +1,6 @@
 class ResourcesController < ApplicationController
   before_action :find_resource, only: [:show, :update, :destroy]
+  before_action :require_state, only: [:create, :search]
 
   def show
     render json: @resource
@@ -35,7 +36,24 @@ class ResourcesController < ApplicationController
     render json: @resource
   end
 
+  def search
+    begin
+      @resource = Resource.find_by!(
+        resource_category_id: params[:resource_category_id],
+        state: params[:state]
+      )
+    rescue ActiveRecord::RecordNotFound
+      render status: 404, json: {} and return
+    end
+
+    render status: 200, json: @resource
+  end
+
   private
+
+  def require_state
+    render status: 400, json: { error: "Missing state parameter"} and return unless params[:state].present?
+  end
 
   def find_resource
     begin

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -19,8 +19,12 @@ class ResourcesController < ApplicationController
 
   def update
     # TODO: authenticate admin user
-    attributes = params.permit(upsert_params(Resource))
-    @resource.update!(attributes)
+    begin
+      attributes = params.permit(upsert_params(Resource))
+      @resource.update!(attributes)
+    rescue ActiveRecord::RecordInvalid => e
+      render status: 400, json: { error: e.message } and return
+    end
 
     render json: @resource
   end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,3 +1,10 @@
+require 'carmen'
+
 class Resource < ApplicationRecord
+    include Carmen
+
+    STATE_CODES = Country.named('United States').subregions.map(&:code)
     # belongs_to :resource_category
+
+    validates :state, inclusion: { in: STATE_CODES, message: "%{value} is not a valid US state code" }
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -6,5 +6,5 @@ class Resource < ApplicationRecord
     STATE_CODES = Country.named('United States').subregions.map(&:code)
     # belongs_to :resource_category
 
-    validates :state, inclusion: { in: STATE_CODES, message: "%{value} is not a valid US state code" }
+    validates :state, inclusion: { in: STATE_CODES, allow_nil: true, message: "%{value} is not a valid US state code" }
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -2,9 +2,9 @@ require 'carmen'
 
 class Resource < ApplicationRecord
     include Carmen
-
     STATE_CODES = Country.named('United States').subregions.map(&:code)
-    # belongs_to :resource_category
+
+    belongs_to :resource_category
 
     validates :state, inclusion: { in: STATE_CODES, allow_nil: true, message: "%{value} is not a valid US state code" }
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,0 +1,3 @@
+class Resource < ApplicationRecord
+    belongs_to :resource_category
+end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,3 +1,3 @@
 class Resource < ApplicationRecord
-    belongs_to :resource_category
+    # belongs_to :resource_category
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -6,5 +6,5 @@ class Resource < ApplicationRecord
 
     belongs_to :resource_category
 
-    validates :state, inclusion: { in: STATE_CODES, allow_nil: true, message: "%{value} is not a valid US state code" }
+    validates :state, inclusion: { in: STATE_CODES, message: "%{value} is not a valid US state code" }
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -7,4 +7,5 @@ class Resource < ApplicationRecord
     belongs_to :resource_category
 
     validates :state, inclusion: { in: STATE_CODES, message: "%{value} is not a valid US state code" }
+    validates :state, uniqueness: { scope: :resource_category_id, message: "should be unique within each resource category" }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
-  resources :resource_categories, only: [:show, :create, :update, :destroy]
-  resources :resources, only: [:show, :create, :update, :destroy]
+  resources :resource_categories, only: [:show, :create, :update, :destroy] do
+    resources :resources, only: [:create]
+  end
+
+  resources :resources, only: [:show, :update, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
     resources :resources, only: [:create]
   end
 
+  get 'resource_categories/:resource_category_id/resources', to: 'resources#search'
+
   resources :resources, only: [:show, :update, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   resources :resource_categories, only: [:show, :create, :update, :destroy]
+  resources :resources, only: [:show, :create, :update, :destroy]
 end

--- a/db/migrate/20190722091140_create_resources.rb
+++ b/db/migrate/20190722091140_create_resources.rb
@@ -14,5 +14,7 @@ class CreateResources < ActiveRecord::Migration[5.2]
 
       t.timestamps
     end
+
+    add_index :resources, [:resource_category_id, :state], unique: true
   end
 end

--- a/db/migrate/20190722091140_create_resources.rb
+++ b/db/migrate/20190722091140_create_resources.rb
@@ -10,7 +10,7 @@ class CreateResources < ActiveRecord::Migration[5.2]
       t.text    :story
       t.text    :challenges
 
-      # t.belongs_to  :resource_category, index: true
+      t.belongs_to  :resource_category, index: true
 
       t.timestamps
     end

--- a/db/migrate/20190722091140_create_resources.rb
+++ b/db/migrate/20190722091140_create_resources.rb
@@ -10,7 +10,7 @@ class CreateResources < ActiveRecord::Migration[5.2]
       t.text    :story
       t.text    :challenges
 
-      t.belongs_to  :resource_category, index: true
+      # t.belongs_to  :resource_category, index: true
 
       t.timestamps
     end

--- a/db/migrate/20190722091140_create_resources.rb
+++ b/db/migrate/20190722091140_create_resources.rb
@@ -1,0 +1,18 @@
+class CreateResources < ActiveRecord::Migration[5.2]
+  def change
+    create_table :resources do |t|
+      t.string  :state
+      t.text    :time
+      t.text    :cost
+      t.text    :award
+      t.text    :likelihood
+      t.text    :safety
+      t.text    :story
+      t.text    :challenges
+
+      t.belongs_to  :resource_category, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,10 +37,8 @@ ActiveRecord::Schema.define(version: 2019_07_22_091140) do
     t.text "safety"
     t.text "story"
     t.text "challenges"
-    t.bigint "resource_category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["resource_category_id"], name: "index_resources_on_resource_category_id"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2019_07_22_091140) do
     t.bigint "resource_category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["resource_category_id", "state"], name: "index_resources_on_resource_category_id_and_state", unique: true
     t.index ["resource_category_id"], name: "index_resources_on_resource_category_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,8 +37,10 @@ ActiveRecord::Schema.define(version: 2019_07_22_091140) do
     t.text "safety"
     t.text "story"
     t.text "challenges"
+    t.bigint "resource_category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["resource_category_id"], name: "index_resources_on_resource_category_id"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_15_133218) do
+ActiveRecord::Schema.define(version: 2019_07_22_091140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,21 @@ ActiveRecord::Schema.define(version: 2019_07_15_133218) do
     t.binary "share_image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "resources", force: :cascade do |t|
+    t.string "state"
+    t.text "time"
+    t.text "cost"
+    t.text "award"
+    t.text "likelihood"
+    t.text "safety"
+    t.text "story"
+    t.text "challenges"
+    t.bigint "resource_category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["resource_category_id"], name: "index_resources_on_resource_category_id"
   end
 
 end

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+require 'spec_helper'
+
+describe ResourcesController, type: :controller do
+  describe '#show' do
+    let(:id) { 1000 }
+
+    context 'where resource exists' do
+      before do
+        resource = build(:resource, id: id)
+        resource.save!
+      end
+
+      it 'returns 200 and the resource' do
+        get :show, params: { id: id }
+        expect(response.status).to eq(200)
+
+        body = JSON.parse(response.body)
+        expect(body['id']).to eq(id)
+      end
+    end
+
+    context 'where the resource doesn\'t exist' do
+      it 'returns 404' do
+        get :show, params: { id: id }
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe '#create' do
+    it 'returns 201 and the resource' do
+      post :create
+      expect(response.status).to eq(201)
+
+      body = JSON.parse(response.body)
+      expect(body['id']).to be_a(Integer)
+    end
+  end
+
+  describe '#destroy' do
+    let(:id) { 1000 }
+
+    before do
+      resource = build(:resource, id: id)
+      resource.save!
+    end
+
+    it 'returns 204 and an empty body' do
+      delete :destroy, params: { id: id }
+      expect(response.status).to eq(204)
+
+      body = JSON.parse(response.body)
+      expect(body).to be_empty
+    end
+  end
+
+  describe '#update' do
+    let(:id) { 1000 }
+
+    context 'where resource doesn\'t exist' do
+      it 'returns 404 and an empty body' do
+        put :update, params: { id: id }
+        expect(response.status).to eq(404)
+
+        body = JSON.parse(response.body)
+        expect(body).to be_empty
+      end
+    end
+
+    context 'where resource does exist' do
+      let(:resource) { build(:resource, id: id) }
+
+      before do
+        resource.save!
+      end
+
+      context 'and update succeeds' do
+        let(:params) do
+          {
+            state: 'NY',
+            time: 'Months. Note: Depending on the case, it could take longer.',
+            cost: 'It is free of charge.',
+            award: 'You can potentially claim full amount of reasonable losses in awards for shattered computer, ER visits, or lost days from work.',
+            likelihood: 'The likelihood to get reimbursement through this option depends on whether a criminal case is brought. The system takes care of everything but that only happens if the evidence is strong enough for a prosecutor to bring charges.',
+            safety: 'It is likely that the prosecutor will call you to testify in the criminal case with your abuser present.',
+            story: 'You will have to share your story when you make a report to law enforcement and if you are called to testify, you will have to do so on the stand at trial.'
+          }
+        end
+
+        it 'returns 200 and new resource' do
+          put :update, params: params.merge({ id: id })
+          expect(response.status).to eq(200)
+
+          body = JSON.parse(response.body)
+          keys = %w(description name seo_description seo_keywords seo_title short_description)
+
+          keys.each do |key|
+            expect(body[key]).to eq(params[key.to_sym])
+          end
+        end
+
+        context 'only altering one field' do
+          let(:new_state) { 'ME' }
+          let(:old_time) { 'Months. Note: Depending on the case, it could take longer.' }
+          let(:params) { { state: new_state } }
+
+          before do
+            resource.time = old_time
+            resource.save!
+          end
+
+          it 'updates the fields passed into the params and does not modify anything else' do
+            put :update, params: params.merge({ id: id })
+            expect(response.status).to eq(200)
+
+            body = JSON.parse(response.body)
+            expect(body['state']).to eq(new_state)
+            expect(body['time']).to eq(old_time)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -7,8 +7,7 @@ describe ResourcesController, type: :controller do
 
     context 'where resource exists' do
       before do
-        resource = build(:resource, id: id)
-        resource.save!
+        resource = create(:resource, :with_resource_category, id: id)
       end
 
       it 'returns 200 and the resource' do
@@ -42,8 +41,7 @@ describe ResourcesController, type: :controller do
     let(:id) { 1000 }
 
     before do
-      resource = build(:resource, id: id)
-      resource.save!
+      resource = create(:resource, :with_resource_category, id: id)
     end
 
     it 'returns 204 and an empty body' do
@@ -69,11 +67,8 @@ describe ResourcesController, type: :controller do
     end
 
     context 'where resource does exist' do
-      let(:resource) { build(:resource, id: id) }
-
-      before do
-        resource.save!
-      end
+      let!(:resource) { create(:resource, :with_resource_category, id: id) }
+      let!(:new_resource_category) { create(:resource_category) }
 
       context 'and update succeeds' do
         let(:params) do
@@ -84,7 +79,8 @@ describe ResourcesController, type: :controller do
             award: 'You can potentially claim full amount of reasonable losses in awards for shattered computer, ER visits, or lost days from work.',
             likelihood: 'The likelihood to get reimbursement through this option depends on whether a criminal case is brought. The system takes care of everything but that only happens if the evidence is strong enough for a prosecutor to bring charges.',
             safety: 'It is likely that the prosecutor will call you to testify in the criminal case with your abuser present.',
-            story: 'You will have to share your story when you make a report to law enforcement and if you are called to testify, you will have to do so on the stand at trial.'
+            story: 'You will have to share your story when you make a report to law enforcement and if you are called to testify, you will have to do so on the stand at trial.',
+            resource_category_id: new_resource_category.id.to_i,
           }
         end
 
@@ -93,7 +89,7 @@ describe ResourcesController, type: :controller do
           expect(response.status).to eq(200)
 
           body = JSON.parse(response.body)
-          keys = %w(description name seo_description seo_keywords seo_title short_description)
+          keys = %w(state time cost award likelihood safety story resource_category_id)
 
           keys.each do |key|
             expect(body[key]).to eq(params[key.to_sym])

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -119,6 +119,19 @@ describe ResourcesController, type: :controller do
             expect(body['time']).to eq(old_time)
           end
         end
+
+        context 'with an invalid field' do
+          let(:new_state) { 'XO' }
+          let(:params) { { state: new_state } }
+
+          it 'returns 400 and an error message' do
+            put :update, params: params.merge({ id: id })
+            expect(response.status).to eq(400)
+            
+            body = JSON.parse(response.body)
+            expect(body['error']).to eq("Validation failed: State #{new_state} is not a valid US state code")
+          end
+        end
       end
     end
   end

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -28,8 +28,38 @@ describe ResourcesController, type: :controller do
   end
 
   describe '#create' do
+    let!(:resource_category) { create(:resource_category) }
+    let(:resource_category_id) { resource_category.id.to_i }
+    let(:state) { 'NY' }
+
+    let(:params) { { resource_category_id: resource_category_id, state: state } }
+
+    context 'an invalid resource category id' do
+      let(:resource_category_id) { 'fake-id' }
+
+      it 'returns 400 and an error' do
+        post :create, params: params
+        expect(response.status).to eq(400)
+        
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq("Validation failed: Resource category must exist")
+      end
+    end
+
+    context 'without state' do
+      let(:state) { nil }
+
+      it 'returns 400 and an error' do
+        post :create, params: params
+        expect(response.status).to eq(400)
+        
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq("Validation failed: State  is not a valid US state code")
+      end
+    end
+
     it 'returns 201 and the resource' do
-      post :create
+      post :create, params: params
       expect(response.status).to eq(201)
 
       body = JSON.parse(response.body)

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :resource do
+    state { 'NY' }
+
     trait :with_resource_category do
       resource_category
     end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :resource do
+    
+  end
+end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :resource do
-  
+    trait :with_resource_category do
+      resource_category
+    end
   end
 end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :resource do
-    
+  
   end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -5,21 +5,34 @@ RSpec.describe Resource, type: :model do
     context 'when state code is invalid' do
       it 'returns false' do
         resource = build(:resource, :with_resource_category, state: 'XO')
-        expect(resource.valid?).to be false
+        expect(resource).not_to be_valid
       end
     end
     
     context 'when state code is valid' do
       it 'returns true' do
         resource = build(:resource, :with_resource_category, state: 'NY')
-        expect(resource.valid?).to be true
+        expect(resource).to be_valid
       end
     end
 
     context 'with no resource category' do
       it 'returns false' do
         resource = build(:resource)
-        expect(resource.valid?).to be false
+        expect(resource).not_to be_valid
+      end
+    end
+
+    context 'not unique on state/resource_category_id' do
+      let!(:resource_category) { create(:resource_category) }
+
+      before do
+        create(:resource, resource_category_id: resource_category.id, state: 'NY')
+      end
+
+      it 'returns false' do
+        resource = build(:resource, resource_category_id: resource_category.id, state: 'NY')
+        expect(resource).not_to be_valid
       end
     end
   end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe Resource, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#valid?' do
+    context 'when state code is invalid' do
+      it 'returns false' do
+        resource = build(:resource, state: 'XO')
+        expect(resource.valid?).to be false
+      end
+    end
+    
+    context 'when state code is valid' do
+      it 'returns true' do
+        resource = build(:resource, state: 'NY')
+        expect(resource.valid?).to be true
+      end
+    end
+  end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -4,22 +4,29 @@ RSpec.describe Resource, type: :model do
   describe '#valid?' do
     context 'when state code is invalid' do
       it 'returns false' do
-        resource = build(:resource, state: 'XO')
+        resource = build(:resource, :with_resource_category, state: 'XO')
         expect(resource.valid?).to be false
       end
     end
     
     context 'when state code is valid' do
       it 'returns true' do
-        resource = build(:resource, state: 'NY')
+        resource = build(:resource, :with_resource_category, state: 'NY')
         expect(resource.valid?).to be true
       end
     end
 
     context 'when state code is nil' do
       it 'returns true' do
-        resource = build(:resource)
+        resource = build(:resource, :with_resource_category)
         expect(resource.valid?).to be true
+      end
+    end
+
+    context 'with no resource category' do
+      it 'returns false' do
+        resource = build(:resource, state: 'NY')
+        expect(resource.valid?).to be false
       end
     end
   end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -16,16 +16,9 @@ RSpec.describe Resource, type: :model do
       end
     end
 
-    context 'when state code is nil' do
-      it 'returns true' do
-        resource = build(:resource, :with_resource_category)
-        expect(resource.valid?).to be true
-      end
-    end
-
     context 'with no resource category' do
       it 'returns false' do
-        resource = build(:resource, state: 'NY')
+        resource = build(:resource)
         expect(resource.valid?).to be false
       end
     end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -15,5 +15,12 @@ RSpec.describe Resource, type: :model do
         expect(resource.valid?).to be true
       end
     end
+
+    context 'when state code is nil' do
+      it 'returns true' do
+        resource = build(:resource)
+        expect(resource.valid?).to be true
+      end
+    end
   end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Resource, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR introduces a Resource model and controller. The API is as follows:
- GET `/resources/:id`
- UPDATE `/resources/:id`
- DELETE `/resources/:id`
- CREATE `/resource-categories/:resource_category_id/resources/:id?state=:state` (you can't create a resource without associating it with a resource category and state)
- GET `/resource-categories/:resource_category_id/resources/:id?state=:state` (the resources table is indexed on resource_category_id/state to easily search on the fields that differentiate the resources)

Addresses issue #8.