### PR TITLE
Resource Step model and controller

### DIFF
--- a/app/controllers/resource_steps_controller.rb
+++ b/app/controllers/resource_steps_controller.rb
@@ -1,0 +1,48 @@
+class ResourceStepsController < ApplicationController
+  before_action :find_resource_step, only: [:show, :update, :destroy]
+
+  def show
+    render json: @resource_step    
+  end
+
+  def create
+    # TODO: authenticate admin user
+    render status: 400, json: { error: 'Missing number parameter' } and return unless params[:number].present?
+    @resource_step = ResourceStep.new(resource_id: params[:resource_id], number: params[:number])
+
+    begin
+      @resource_step.save!
+    rescue ActiveRecord::RecordInvalid => e
+      render status: 400, json: { error: e.message } and return
+    end
+    render status: 201, json: @resource_step
+  end
+
+  def destroy
+    # TODO: authenticate admin user
+    @resource_step.destroy
+    render status: 204, json: {}
+  end
+
+  def update
+    # TODO: authenticate admin user
+    begin
+      attributes = params.permit(upsert_params(ResourceStep))
+      @resource_step.update!(attributes)
+    rescue ActiveRecord::RecordInvalid => e
+      render status: 400, json: { error: e.message } and return
+    end
+
+    render json: @resource_step
+  end
+
+  private
+
+  def find_resource_step
+    begin
+      @resource_step = ResourceStep.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render status: 404, json: {} and return
+    end
+  end
+end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,5 +1,5 @@
 class ResourcesController < ApplicationController
-  before_action :find_resource, only: [:show, :update, :destroy]
+  before_action :find_resource, only: [:show, :update, :destroy, :list_steps]
   before_action :require_state, only: [:create, :search]
 
   def show
@@ -47,6 +47,10 @@ class ResourcesController < ApplicationController
     end
 
     render status: 200, json: @resource
+  end
+
+  def list_steps
+    render json: @resource.resource_steps
   end
 
   private

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,5 +1,5 @@
 class ResourcesController < ApplicationController
-  before_action :find_resource, only: [:show, :update, :destroy, :list_steps]
+  before_action :find_resource, only: [:show, :update, :destroy, :steps]
   before_action :require_state, only: [:create, :search]
 
   def show
@@ -49,7 +49,7 @@ class ResourcesController < ApplicationController
     render status: 200, json: @resource
   end
 
-  def list_steps
+  def steps
     render json: @resource.resource_steps
   end
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -4,7 +4,8 @@ class Resource < ApplicationRecord
     include Carmen
     STATE_CODES = Country.named('United States').subregions.map(&:code)
 
-    belongs_to :resource_category
+    belongs_to  :resource_category
+    has_many    :resource_steps
 
     validates :state, inclusion: { in: STATE_CODES, message: "%{value} is not a valid US state code" }
     validates :state, uniqueness: { scope: :resource_category_id, message: "should be unique within each resource category" }

--- a/app/models/resource_step.rb
+++ b/app/models/resource_step.rb
@@ -1,0 +1,4 @@
+class ResourceStep < ApplicationRecord
+  belongs_to :resource
+  validates :number, uniqueness: { scope: :resource_id, message: "should be unique within each resource"}
+end

--- a/app/models/resource_step.rb
+++ b/app/models/resource_step.rb
@@ -1,4 +1,4 @@
 class ResourceStep < ApplicationRecord
   belongs_to :resource
-  validates :number, uniqueness: { scope: :resource_id, message: "should be unique within each resource"}
+  validates :number, uniqueness: { scope: :resource_id, message: "should be unique within each resource"}, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,10 @@ Rails.application.routes.draw do
 
   resources :resources, only: [:show, :update, :destroy] do
     resources :resource_steps, only: [:create]
-    # TODO: list resource steps for resource
   end
+
+  # TODO: refactor this route
+  get 'resources/:id/resource_steps', to: 'resources#list_steps'
+
   resources :resource_steps, only: [:show, :update, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,8 @@ Rails.application.routes.draw do
 
   resources :resources, only: [:show, :update, :destroy] do
     resources :resource_steps, only: [:create]
+    get 'resource_steps', on: :member, to: 'resources#list_steps'
   end
-
-  # TODO: refactor this route
-  get 'resources/:id/resource_steps', to: 'resources#list_steps'
 
   resources :resource_steps, only: [:show, :update, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   resources :resources, only: [:show, :update, :destroy] do
     resources :resource_steps, only: [:create]
-    get 'resource_steps', on: :member, to: 'resources#list_steps'
+    get 'resource_steps', on: :member, to: 'resources#steps'
   end
 
   resources :resource_steps, only: [:show, :update, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,9 @@ Rails.application.routes.draw do
 
   get 'resource_categories/:resource_category_id/resources', to: 'resources#search'
 
-  resources :resources, only: [:show, :update, :destroy]
+  resources :resources, only: [:show, :update, :destroy] do
+    resources :resource_steps, only: [:create]
+    # TODO: list resource steps for resource
+  end
+  resources :resource_steps, only: [:show, :update, :destroy]
 end

--- a/db/migrate/20190722091140_create_resources.rb
+++ b/db/migrate/20190722091140_create_resources.rb
@@ -10,7 +10,7 @@ class CreateResources < ActiveRecord::Migration[5.2]
       t.text    :story
       t.text    :challenges
 
-      t.belongs_to  :resource_category
+      t.belongs_to  :resource_category, index: true
 
       t.timestamps
     end

--- a/db/migrate/20190722091140_create_resources.rb
+++ b/db/migrate/20190722091140_create_resources.rb
@@ -10,7 +10,7 @@ class CreateResources < ActiveRecord::Migration[5.2]
       t.text    :story
       t.text    :challenges
 
-      t.belongs_to  :resource_category, index: true
+      t.belongs_to  :resource_category
 
       t.timestamps
     end

--- a/db/migrate/20190723112123_create_resource_steps.rb
+++ b/db/migrate/20190723112123_create_resource_steps.rb
@@ -1,0 +1,10 @@
+class CreateResourceSteps < ActiveRecord::Migration[5.2]
+  def change
+    create_table :resource_steps do |t|
+      t.integer     :number 
+      t.text        :description
+      t.belongs_to  :resource
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190723112123_create_resource_steps.rb
+++ b/db/migrate/20190723112123_create_resource_steps.rb
@@ -3,7 +3,7 @@ class CreateResourceSteps < ActiveRecord::Migration[5.2]
     create_table :resource_steps do |t|
       t.integer     :number 
       t.text        :description
-      t.belongs_to  :resource
+      t.belongs_to  :resource, index: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_22_091140) do
+ActiveRecord::Schema.define(version: 2019_07_23_112123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,15 @@ ActiveRecord::Schema.define(version: 2019_07_22_091140) do
     t.binary "share_image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "resource_steps", force: :cascade do |t|
+    t.integer "number"
+    t.text "description"
+    t.bigint "resource_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["resource_id"], name: "index_resource_steps_on_resource_id"
   end
 
   create_table "resources", force: :cascade do |t|

--- a/spec/controllers/resource_steps_controller_spec.rb
+++ b/spec/controllers/resource_steps_controller_spec.rb
@@ -1,0 +1,222 @@
+require 'rails_helper'
+require 'spec_helper'
+
+describe ResourceStepsController, type: :controller do
+  describe '#show' do
+    let(:id) { 1000 }
+
+    context 'where resource step exists' do
+      before do
+        resource_step = create(:resource_step, :with_resource, id: id)
+      end
+
+      it 'returns 200 and the resource' do
+        get :show, params: { id: id }
+        expect(response.status).to eq(200)
+
+        body = JSON.parse(response.body)
+        expect(body['id']).to eq(id)
+      end
+    end
+
+    context 'where the resource step doesn\'t exist' do
+      it 'returns 404' do
+        get :show, params: { id: id }
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe '#create' do
+    let!(:resource_category) { create(:resource_category) }
+    let(:resource_category_id) { resource_category.id.to_i }
+    let(:state) { 'NY' }
+
+    let(:params) { { resource_category_id: resource_category_id, state: state } }
+
+    context 'an invalid resource category id' do
+      let(:resource_category_id) { 'fake-id' }
+
+      it 'returns 400 and an error' do
+        post :create, params: params
+        expect(response.status).to eq(400)
+        
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq("Validation failed: Resource category must exist")
+      end
+    end
+
+    context 'without state' do
+      let(:state) { nil }
+
+      it 'returns 400 and an error' do
+        post :create, params: params
+        expect(response.status).to eq(400)
+        
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq("Missing state parameter")
+      end
+    end
+
+    it 'returns 201 and the resource' do
+      post :create, params: params
+      expect(response.status).to eq(201)
+
+      body = JSON.parse(response.body)
+      expect(body['id']).to be_a(Integer)
+    end
+  end
+
+  describe '#destroy' do
+    let(:id) { 1000 }
+
+    before do
+      resource = create(:resource, :with_resource_category, id: id)
+    end
+
+    it 'returns 204 and an empty body' do
+      delete :destroy, params: { id: id }
+      expect(response.status).to eq(204)
+
+      body = JSON.parse(response.body)
+      expect(body).to be_empty
+    end
+  end
+
+  describe '#update' do
+    let(:id) { 1000 }
+
+    context 'where resource doesn\'t exist' do
+      it 'returns 404 and an empty body' do
+        put :update, params: { id: id }
+        expect(response.status).to eq(404)
+
+        body = JSON.parse(response.body)
+        expect(body).to be_empty
+      end
+    end
+
+    context 'where resource does exist' do
+      let!(:resource) { create(:resource, :with_resource_category, id: id) }
+      let!(:new_resource_category) { create(:resource_category) }
+
+      context 'and update succeeds' do
+        let(:params) do
+          {
+            state: 'NY',
+            time: 'Months. Note: Depending on the case, it could take longer.',
+            cost: 'It is free of charge.',
+            award: 'You can potentially claim full amount of reasonable losses in awards for shattered computer, ER visits, or lost days from work.',
+            likelihood: 'The likelihood to get reimbursement through this option depends on whether a criminal case is brought. The system takes care of everything but that only happens if the evidence is strong enough for a prosecutor to bring charges.',
+            safety: 'It is likely that the prosecutor will call you to testify in the criminal case with your abuser present.',
+            story: 'You will have to share your story when you make a report to law enforcement and if you are called to testify, you will have to do so on the stand at trial.',
+            resource_category_id: new_resource_category.id.to_i,
+          }
+        end
+
+        it 'returns 200 and new resource' do
+          put :update, params: params.merge({ id: id })
+          expect(response.status).to eq(200)
+
+          body = JSON.parse(response.body)
+          keys = %w(state time cost award likelihood safety story resource_category_id)
+
+          keys.each do |key|
+            expect(body[key]).to eq(params[key.to_sym])
+          end
+        end
+
+        context 'only altering one field' do
+          let(:new_state) { 'ME' }
+          let(:old_time) { 'Months. Note: Depending on the case, it could take longer.' }
+          let(:params) { { state: new_state } }
+
+          before do
+            resource.time = old_time
+            resource.save!
+          end
+
+          it 'updates the fields passed into the params and does not modify anything else' do
+            put :update, params: params.merge({ id: id })
+            expect(response.status).to eq(200)
+
+            body = JSON.parse(response.body)
+            expect(body['state']).to eq(new_state)
+            expect(body['time']).to eq(old_time)
+          end
+        end
+
+        context 'with an invalid field' do
+          let(:new_state) { 'XO' }
+          let(:params) { { state: new_state } }
+
+          it 'returns 400 and an error message' do
+            put :update, params: params.merge({ id: id })
+            expect(response.status).to eq(400)
+            
+            body = JSON.parse(response.body)
+            expect(body['error']).to eq("Validation failed: State #{new_state} is not a valid US state code")
+          end
+        end
+      end
+    end
+  end
+
+  describe '#search' do
+    let!(:resource_category) { create(:resource_category) }
+    let!(:resource) { create(:resource, state: 'NY', resource_category_id: resource_category.id) }
+
+    let(:state) { 'NY' }
+    let(:resource_category_id) { resource_category.id.to_i }
+
+    let(:params) { { resource_category_id: resource_category_id, state: state } }
+
+    context 'without state param' do
+      let(:state) { nil }
+
+      it 'returns 400' do
+        get :search, params: params
+        expect(response.status).to eq(400)
+        
+        body = JSON.parse(response.body)
+        expect(body['error']).to eq('Missing state parameter')
+      end
+    end
+
+    context 'where resource exists for category but not state' do
+      let(:state) { 'ME' }
+
+      it 'returns 404' do
+        get :search, params: params
+        expect(response.status).to eq(404)
+        
+        body = JSON.parse(response.body)
+        expect(body).to be_empty
+      end
+    end
+
+    context 'where resource exists for state but not category' do
+      let(:resource_category_id) { 'fake-id' }
+
+      it 'returns 404' do
+        get :search, params: params
+        expect(response.status).to eq(404)
+        
+        body = JSON.parse(response.body)
+        expect(body).to be_empty
+      end
+    end
+
+    context 'where resource exists for state and category' do
+      it 'returns 200' do
+        get :search, params: params
+        expect(response.status).to eq(200)
+        
+        body = JSON.parse(response.body)
+        expect(body['id']).to eq(resource.id.to_i)
+        expect(body['resource_category_id']).to eq(resource_category_id)
+        expect(body['state']).to eq(state)
+      end
+    end
+  end
+end

--- a/spec/controllers/resource_steps_controller_spec.rb
+++ b/spec/controllers/resource_steps_controller_spec.rb
@@ -124,13 +124,13 @@ describe ResourceStepsController, type: :controller do
         end
 
         context 'only altering one field' do
-          let(:new_state) { 'ME' }
-          let(:old_time) { 'Months. Note: Depending on the case, it could take longer.' }
-          let(:params) { { state: new_state } }
+          let(:new_description) { 'New resource step description' }
+          let(:old_number) { 1 }
+          let(:params) { { description: new_description } }
 
           before do
-            resource.time = old_time
-            resource.save!
+            resource_step.number = old_number
+            resource_step.save!
           end
 
           it 'updates the fields passed into the params and does not modify anything else' do
@@ -138,81 +138,23 @@ describe ResourceStepsController, type: :controller do
             expect(response.status).to eq(200)
 
             body = JSON.parse(response.body)
-            expect(body['state']).to eq(new_state)
-            expect(body['time']).to eq(old_time)
+            expect(body['description']).to eq(new_description)
+            expect(body['number']).to eq(old_number)
           end
         end
 
         context 'with an invalid field' do
-          let(:new_state) { 'XO' }
-          let(:params) { { state: new_state } }
+          let(:new_number) { nil }
+          let(:params) { { number: new_number } }
 
           it 'returns 400 and an error message' do
             put :update, params: params.merge({ id: id })
             expect(response.status).to eq(400)
             
             body = JSON.parse(response.body)
-            expect(body['error']).to eq("Validation failed: State #{new_state} is not a valid US state code")
+            expect(body['error']).to eq("Validation failed: Number can't be blank")
           end
         end
-      end
-    end
-  end
-
-  describe '#search' do
-    let!(:resource_category) { create(:resource_category) }
-    let!(:resource) { create(:resource, state: 'NY', resource_category_id: resource_category.id) }
-
-    let(:state) { 'NY' }
-    let(:resource_category_id) { resource_category.id.to_i }
-
-    let(:params) { { resource_category_id: resource_category_id, state: state } }
-
-    context 'without state param' do
-      let(:state) { nil }
-
-      it 'returns 400' do
-        get :search, params: params
-        expect(response.status).to eq(400)
-        
-        body = JSON.parse(response.body)
-        expect(body['error']).to eq('Missing state parameter')
-      end
-    end
-
-    context 'where resource exists for category but not state' do
-      let(:state) { 'ME' }
-
-      it 'returns 404' do
-        get :search, params: params
-        expect(response.status).to eq(404)
-        
-        body = JSON.parse(response.body)
-        expect(body).to be_empty
-      end
-    end
-
-    context 'where resource exists for state but not category' do
-      let(:resource_category_id) { 'fake-id' }
-
-      it 'returns 404' do
-        get :search, params: params
-        expect(response.status).to eq(404)
-        
-        body = JSON.parse(response.body)
-        expect(body).to be_empty
-      end
-    end
-
-    context 'where resource exists for state and category' do
-      it 'returns 200' do
-        get :search, params: params
-        expect(response.status).to eq(200)
-        
-        body = JSON.parse(response.body)
-        expect(body['id']).to eq(resource.id.to_i)
-        expect(body['resource_category_id']).to eq(resource_category_id)
-        expect(body['state']).to eq(state)
       end
     end
   end

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -219,4 +219,48 @@ describe ResourcesController, type: :controller do
       end
     end
   end
+
+  describe '#list_steps' do
+    context 'where resource doesn\'t exist' do
+      it 'returns 404' do
+        get :list_steps, params: { id: 'fake-id' }
+        expect(response.status).to eq(404)
+        
+        body = JSON.parse(response.body)
+        expect(body).to be_empty
+      end
+    end
+
+    context 'where resource has no resource steps' do
+      let!(:resource) { create(:resource, :with_resource_category) }
+      it 'returns 200 and an empty array' do
+        get :list_steps, params: { id: resource.id.to_s }
+        expect(response.status).to eq(200)
+
+        body = JSON.parse(response.body)
+        expect(body).to be_a(Array)
+        expect(body).to be_empty
+      end
+    end
+
+    context 'where resource has steps' do
+      let!(:resource) { create(:resource, :with_resource_category) }
+      let!(:resource_step_one) { create(:resource_step, number: 5, resource_id: resource.id) }
+      let!(:resource_step_two) { create(:resource_step, number: 6, resource_id: resource.id) }
+
+      it 'returns 200 and an empty array' do
+        get :list_steps, params: { id: resource.id.to_s }
+        expect(response.status).to eq(200)
+
+        body = JSON.parse(response.body)
+        ids = body.map { |step| step['id'] }
+        numbers = body.map { |step| step['number'] }
+        
+        expect(ids).to include(resource_step_one.id.to_i)
+        expect(ids).to include(resource_step_two.id.to_i)
+        expect(numbers).to include(5)
+        expect(numbers).to include(6)
+      end
+    end
+  end
 end

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -220,10 +220,10 @@ describe ResourcesController, type: :controller do
     end
   end
 
-  describe '#list_steps' do
+  describe '#steps' do
     context 'where resource doesn\'t exist' do
       it 'returns 404' do
-        get :list_steps, params: { id: 'fake-id' }
+        get :steps, params: { id: 'fake-id' }
         expect(response.status).to eq(404)
         
         body = JSON.parse(response.body)
@@ -234,7 +234,7 @@ describe ResourcesController, type: :controller do
     context 'where resource has no resource steps' do
       let!(:resource) { create(:resource, :with_resource_category) }
       it 'returns 200 and an empty array' do
-        get :list_steps, params: { id: resource.id.to_s }
+        get :steps, params: { id: resource.id.to_s }
         expect(response.status).to eq(200)
 
         body = JSON.parse(response.body)
@@ -249,7 +249,7 @@ describe ResourcesController, type: :controller do
       let!(:resource_step_two) { create(:resource_step, number: 6, resource_id: resource.id) }
 
       it 'returns 200 and an empty array' do
-        get :list_steps, params: { id: resource.id.to_s }
+        get :steps, params: { id: resource.id.to_s }
         expect(response.status).to eq(200)
 
         body = JSON.parse(response.body)

--- a/spec/factories/resource_steps.rb
+++ b/spec/factories/resource_steps.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :resource_step do
+    number { 1 }
     trait :with_resource do
       resource { create(:resource, :with_resource_category) }
     end

--- a/spec/factories/resource_steps.rb
+++ b/spec/factories/resource_steps.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :resource_step do
-    
+    trait :with_resource do
+      resource { create(:resource, :with_resource_category) }
+    end
   end
 end

--- a/spec/factories/resource_steps.rb
+++ b/spec/factories/resource_steps.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :resource_step do
+    
+  end
+end

--- a/spec/models/resource_step_spec.rb
+++ b/spec/models/resource_step_spec.rb
@@ -20,5 +20,12 @@ RSpec.describe ResourceStep, type: :model do
         expect(resource_step).to be_valid
       end
     end
+
+    context 'number is nil' do
+      it 'returns false' do
+        resource_step = build(:resource_step, :with_resource, number: nil)
+        expect(resource_step).not_to be_valid
+      end
+    end
   end
 end

--- a/spec/models/resource_step_spec.rb
+++ b/spec/models/resource_step_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe ResourceStep, type: :model do
+  describe '#valid?' do
+    context 'number is not unique within resource' do
+      let!(:resource) { create(:resource, :with_resource_category) }
+      let!(:first_resource_step) { create(:resource_step, resource_id: resource.id, number: 1) }
+
+      it 'returns false' do
+        resource_step = build(:resource_step, resource_id: resource.id, number: 1)
+        expect(resource_step).not_to be_valid
+      end
+    end
+
+    context 'number is unique within resource' do
+      let!(:resource) { create(:resource, :with_resource_category) }
+
+      it 'returns true' do
+        resource_step = build(:resource_step, resource_id: resource.id, number: 1)
+        expect(resource_step).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the ResourceStep model and controller. The API is as follows:
- GET `/resource-steps/:id`
- PUT `/resource-steps/:id`
- DELETE `/resource-steps/:id`
- POST `/resources/:resource_id/resource-steps?number=:number` (you can't create a resource step without assigning it a number within the resource)
- GET `/resources/:resource_id/resource-steps` (list all of the steps in a particular resource)