### PR TITLE
Add admin auth to controllers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'json'
 gem 'carmen'
 gem 'knock'
+gem 'active_model_serializers'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'puma', '~> 3.11'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
@@ -26,6 +26,7 @@ gem 'puma', '~> 3.11'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'json'
 gem 'carmen'
+gem 'knock'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
+    bcrypt (3.1.13)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -64,6 +65,11 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     json (2.2.0)
+    jwt (1.5.6)
+    knock (2.1.1)
+      bcrypt (~> 3.1)
+      jwt (~> 1.5)
+      rails (>= 4.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -158,11 +164,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
   carmen
   factory_bot_rails
   json
+  knock
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.3)
       activesupport (= 5.2.3)
       globalid (>= 0.3.6)
@@ -50,6 +55,8 @@ GEM
     byebug (11.0.1)
     carmen (1.1.3)
       activesupport (>= 3.0.0)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -65,6 +72,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     json (2.2.0)
+    jsonapi-renderer (0.2.2)
     jwt (1.5.6)
     knock (2.1.1)
       bcrypt (~> 3.1)
@@ -164,6 +172,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@ require "#{Rails.root}/lib/helpers/api_helpers"
 
 class ApplicationController < ActionController::API
   include APIHelpers
+  include Knock::Authenticable
+
+  private
+
+  def authenticate_admin
+    return_unauthorized unless !current_user.nil? && current_user.admin?
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,6 @@ class ApplicationController < ActionController::API
   private
 
   def authenticate_admin
-    return_unauthorized unless !current_user.nil? && current_user.admin?
+    render status: 401 and return unless current_user.present? && current_user.admin?
   end
 end

--- a/app/controllers/resource_categories_controller.rb
+++ b/app/controllers/resource_categories_controller.rb
@@ -1,6 +1,6 @@
 class ResourceCategoriesController < ApplicationController
-  before_action :find_resource_category, only: [:show, :update, :destroy]
   before_action :authenticate_admin, only: [:create, :destroy, :update]
+  before_action :find_resource_category, only: [:show, :update, :destroy]
 
   def show
     render json: @resource_category

--- a/app/controllers/resource_categories_controller.rb
+++ b/app/controllers/resource_categories_controller.rb
@@ -1,24 +1,22 @@
 class ResourceCategoriesController < ApplicationController
   before_action :find_resource_category, only: [:show, :update, :destroy]
+  before_action :authenticate_admin, only: [:create, :destroy, :update]
 
   def show
     render json: @resource_category
   end
 
   def create
-    # TODO: authenticate admin user
     @resource_category = ResourceCategory.create
     render status: 201, json: @resource_category
   end
 
   def destroy
-    # TODO: authenticate admin user
     @resource_category.destroy
     render status: 204, json: {}
   end
 
   def update
-    # TODO: authenticate admin user
     attributes = params.permit(upsert_params(ResourceCategory))
     @resource_category.update!(attributes)
 

--- a/app/controllers/resource_steps_controller.rb
+++ b/app/controllers/resource_steps_controller.rb
@@ -1,4 +1,5 @@
 class ResourceStepsController < ApplicationController
+  before_action :authenticate_admin, only: [:create, :update, :destroy]
   before_action :find_resource_step, only: [:show, :update, :destroy]
 
   def show
@@ -6,7 +7,6 @@ class ResourceStepsController < ApplicationController
   end
 
   def create
-    # TODO: authenticate admin user
     render status: 400, json: { error: 'Missing number parameter' } and return unless params[:number].present?
     @resource_step = ResourceStep.new(resource_id: params[:resource_id], number: params[:number])
 
@@ -19,13 +19,11 @@ class ResourceStepsController < ApplicationController
   end
 
   def destroy
-    # TODO: authenticate admin user
     @resource_step.destroy
     render status: 204, json: {}
   end
 
   def update
-    # TODO: authenticate admin user
     begin
       attributes = params.permit(upsert_params(ResourceStep))
       @resource_step.update!(attributes)

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,5 +1,5 @@
 class ResourcesController < ApplicationController
-  before_action :authenticate_user, only: [:create, :update, :destroy]
+  before_action :authenticate_admin, only: [:create, :update, :destroy]
   before_action :find_resource, only: [:show, :update, :destroy, :steps]
   before_action :require_state, only: [:create, :search]
 

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,4 +1,5 @@
 class ResourcesController < ApplicationController
+  before_action :authenticate_user, only: [:create, :update, :destroy]
   before_action :find_resource, only: [:show, :update, :destroy, :steps]
   before_action :require_state, only: [:create, :search]
 
@@ -7,7 +8,6 @@ class ResourcesController < ApplicationController
   end
 
   def create
-    # TODO: authenticate admin user
     @resource = Resource.new(resource_category_id: params[:resource_category_id], state: params[:state])
 
     begin
@@ -19,13 +19,11 @@ class ResourcesController < ApplicationController
   end
 
   def destroy
-    # TODO: authenticate admin user
     @resource.destroy
     render status: 204, json: {}
   end
 
   def update
-    # TODO: authenticate admin user
     begin
       attributes = params.permit(upsert_params(Resource))
       @resource.update!(attributes)

--- a/app/controllers/user_token_controller.rb
+++ b/app/controllers/user_token_controller.rb
@@ -1,0 +1,2 @@
+class UserTokenController < Knock::AuthTokenController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def current
+    render json: current_user
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,9 @@
 class UsersController < ApplicationController
   def current
-    render json: current_user
+    if current_user.present?
+      render json: current_user
+    else
+      render status: 401, json: {}
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,15 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  before_validation { 
+    (self.email = self.email.to_s.downcase) && (self.username = self.username.to_s.downcase) 
+  }
+
+  validates_length_of     :password, maximum: 30, minimum: 8, allow_nil: true, allow_blank: false
+  validates_presence_of   :email, :username
+  validates_uniqueness_of :email, :username
+
+  def admin?
+    role == 'admin'
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :email, :username, :role
+end

--- a/config/initializers/knock.rb
+++ b/config/initializers/knock.rb
@@ -1,0 +1,59 @@
+Knock.setup do |config|
+
+  ## Expiration claim
+  ## ----------------
+  ##
+  ## How long before a token is expired. If nil is provided, token will
+  ## last forever.
+  ##
+  ## Default:
+  config.token_lifetime = 1.week
+
+
+  ## Audience claim
+  ## --------------
+  ##
+  ## Configure the audience claim to identify the recipients that the token
+  ## is intended for.
+  ##
+  ## Default:
+  # config.token_audience = nil
+
+  ## If using Auth0, uncomment the line below
+  # config.token_audience = -> { Rails.application.secrets.auth0_client_id }
+
+  ## Signature algorithm
+  ## -------------------
+  ##
+  ## Configure the algorithm used to encode the token
+  ##
+  ## Default:
+  config.token_signature_algorithm = 'HS256'
+
+  ## Signature key
+  ## -------------
+  ##
+  ## Configure the key used to sign tokens.
+  ##
+  ## Default:
+  config.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
+
+  ## If using Auth0, uncomment the line below
+  # config.token_secret_signature_key = -> { JWT.base64url_decode Rails.application.secrets.auth0_client_secret }
+
+  ## Public key
+  ## ----------
+  ##
+  ## Configure the public key used to decode tokens, if required.
+  ##
+  ## Default:
+  # config.token_public_key = nil
+
+  ## Exception Class
+  ## ---------------
+  ##
+  ## Configure the exception to be used when user cannot be found.
+  ##
+  ## Default:
+  config.not_found_exception_class_name = 'ActiveRecord::RecordNotFound'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  post 'user_token' => 'user_token#create'
+  post 'user-tokens' => 'user_token#create'
   get '/users/current'  => 'users#current'
 
   resources :resource_categories, only: [:show, :create, :update, :destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  post 'user_token' => 'user_token#create'
+  get '/users/current'  => 'users#current'
+
   resources :resource_categories, only: [:show, :create, :update, :destroy] do
     resources :resources, only: [:create]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  post 'user-tokens' => 'user_token#create'
+  post 'user_tokens' => 'user_token#create'
   get '/users/current'  => 'users#current'
 
   resources :resource_categories, only: [:show, :create, :update, :destroy] do

--- a/db/migrate/20190726141248_create_users.rb
+++ b/db/migrate/20190726141248_create_users.rb
@@ -1,0 +1,12 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :username, null: false, unique: true
+      t.string :email, null: false, index: true, unique: true
+      t.string :password_digest
+      t.string :role, null: false, default: 'user'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_23_112123) do
+ActiveRecord::Schema.define(version: 2019_07_26_141248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,16 @@ ActiveRecord::Schema.define(version: 2019_07_23_112123) do
     t.datetime "updated_at", null: false
     t.index ["resource_category_id", "state"], name: "index_resources_on_resource_category_id_and_state", unique: true
     t.index ["resource_category_id"], name: "index_resources_on_resource_category_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "username", null: false
+    t.string "email", null: false
+    t.string "password_digest"
+    t.string "role", default: "user", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email"
   end
 
 end

--- a/spec/controllers/resource_categories_controller_spec.rb
+++ b/spec/controllers/resource_categories_controller_spec.rb
@@ -66,8 +66,7 @@ describe ResourceCategoriesController, type: :controller do
 
   describe '#destroy' do
     before do
-      resource_category = build(:resource_category, id: id)
-      resource_category.save!
+      create(:resource_category, id: id)
     end
 
     context 'without authentication' do

--- a/spec/controllers/resource_categories_controller_spec.rb
+++ b/spec/controllers/resource_categories_controller_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe ResourceCategoriesController, type: :controller do
-  describe '#show' do
-    let(:id) { 1000 }
+  let(:token) { Knock::AuthToken.new(payload: { sub: user.id }).token }
+  let(:headers) { { 'Authorization': "Bearer #{token}" } }
+  let(:id) { 1000 }
 
+  describe '#show' do
     context 'where resource category exists' do
       before do
         resource_category = build(:resource_category, id: id)
@@ -38,8 +40,6 @@ describe ResourceCategoriesController, type: :controller do
 
     context 'with regular user' do
       let(:user) { create(:user) }
-      let(:token) { Knock::AuthToken.new(payload: { sub: user.id }).token }
-      let(:headers) { { 'Authorization': "Bearer #{token}" } }
 
       it 'returns 401' do
         post :create
@@ -49,8 +49,6 @@ describe ResourceCategoriesController, type: :controller do
 
     context 'with admin user' do
       let(:user) { create(:user, :admin) }
-      let(:token) { Knock::AuthToken.new(payload: { sub: user.id }).token }
-      let(:headers) { { 'Authorization': "Bearer #{token}" } }
 
       before do
         request.headers.merge! headers
@@ -67,85 +65,137 @@ describe ResourceCategoriesController, type: :controller do
   end
 
   describe '#destroy' do
-    let(:id) { 1000 }
-
     before do
       resource_category = build(:resource_category, id: id)
       resource_category.save!
     end
 
-    it 'returns 204 and an empty body' do
-      delete :destroy, params: { id: id }
-      expect(response.status).to eq(204)
-
-      body = JSON.parse(response.body)
-      expect(body).to be_empty
+    context 'without authentication' do
+      it 'returns 401' do
+        delete :destroy, params: { id: id }
+        expect(response.status).to eq(401)
+      end
     end
-  end
 
-  describe '#update' do
-    let(:id) { 1000 }
+    context 'with regular user' do
+      let(:user) { create(:user) }
 
-    context 'where resource category doesn\'t exist' do
-      it 'returns 404 and an empty body' do
-        put :update, params: { id: id }
-        expect(response.status).to eq(404)
+      before do
+        request.headers.merge! headers
+      end
+
+      it 'returns 401' do
+        delete :destroy, params: { id: id }
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with admin user' do
+      let(:user) { create(:user, :admin) }
+
+      before do
+        request.headers.merge! headers
+      end
+
+      it 'returns 204 and an empty body' do
+        delete :destroy, params: { id: id }
+        expect(response.status).to eq(204)
 
         body = JSON.parse(response.body)
         expect(body).to be_empty
       end
     end
+  end
 
-    context 'where resource category does exist' do
-      let(:resource_category) { build(:resource_category, id: id) }
+  describe '#update' do
+    context 'with no authentication' do
+      it 'returns 401' do
+        put :update, params: { id: id }
+        expect(response.status).to eq(401)
+      end
+    end
 
+    context 'with regular user' do
+      let(:user) { create(:user) }
+      
       before do
-        resource_category.save!
+        request.headers.merge! headers
       end
 
-      context 'and update succeeds' do
-        let(:params) do
-          {
-            name: 'New name',
-            short_description: 'New short description',
-            description: 'New description',
-            icon: "\x05\x00\x68\x65\x6c\x6c\x6f",
-            seo_title: 'New SEO title',
-            seo_description: 'New SEO description',
-            seo_keywords: ['keyword1', 'keyword2', 'keyword3'],
-            share_image: "\x05\x00\x68\x65\x6c\x6c\x6f",
-          }
-        end
+      it 'returns 401' do
+        put :update, params: { id: id }
+        expect(response.status).to eq(401)
+      end
+    end
 
-        it 'returns 200 and new resource category' do
-          put :update, params: params.merge({ id: id })
-          expect(response.status).to eq(200)
+    context 'with admin user' do
+      let(:user) { create(:user, :admin) }
+
+      before do
+        request.headers.merge! headers
+      end
+
+      context 'where resource category doesn\'t exist' do
+        it 'returns 404 and an empty body' do
+          put :update, params: { id: id }
+          expect(response.status).to eq(404)
 
           body = JSON.parse(response.body)
-          keys = %w(description name seo_description seo_keywords seo_title short_description)
+          expect(body).to be_empty
+        end
+      end
 
-          keys.each do |key|
-            expect(body[key]).to eq(params[key.to_sym])
-          end
+      context 'where resource category does exist' do
+        let(:resource_category) { build(:resource_category, id: id) }
+
+        before do
+          resource_category.save!
         end
 
-        context 'only altering one field' do
-          let(:new_name) { 'New name' }
-          let(:old_description) { 'Here\'s a description I want to keep' }
-          let(:params) { { name: new_name } }
-
-          before do
-            resource_category.description = old_description
-            resource_category.save!
+        context 'and update succeeds' do
+          let(:params) do
+            {
+              name: 'New name',
+              short_description: 'New short description',
+              description: 'New description',
+              icon: "\x05\x00\x68\x65\x6c\x6c\x6f",
+              seo_title: 'New SEO title',
+              seo_description: 'New SEO description',
+              seo_keywords: ['keyword1', 'keyword2', 'keyword3'],
+              share_image: "\x05\x00\x68\x65\x6c\x6c\x6f",
+            }
           end
 
-          it 'updates the fields passed into the params and does not modify anything else' do
+          it 'returns 200 and new resource category' do
             put :update, params: params.merge({ id: id })
             expect(response.status).to eq(200)
 
             body = JSON.parse(response.body)
-            expect(body['name']).to eq(new_name)
-            expect(body['description']).to eq(old_description)
+            keys = %w(description name seo_description seo_keywords seo_title short_description)
+
+            keys.each do |key|
+              expect(body[key]).to eq(params[key.to_sym])
+            end
+          end
+
+          context 'only altering one field' do
+            let(:new_name) { 'New name' }
+            let(:old_description) { 'Here\'s a description I want to keep' }
+            let(:params) { { name: new_name } }
+
+            before do
+              resource_category.description = old_description
+              resource_category.save!
+            end
+
+            it 'updates the fields passed into the params and does not modify anything else' do
+              put :update, params: params.merge({ id: id })
+              expect(response.status).to eq(200)
+
+              body = JSON.parse(response.body)
+              expect(body['name']).to eq(new_name)
+              expect(body['description']).to eq(old_description)
+            end
           end
         end
       end

--- a/spec/controllers/resource_categories_controller_spec.rb
+++ b/spec/controllers/resource_categories_controller_spec.rb
@@ -29,12 +29,40 @@ describe ResourceCategoriesController, type: :controller do
   end
 
   describe '#create' do
-    it 'returns 201 and the resource category' do
-      post :create
-      expect(response.status).to eq(201)
+    context 'without authentication' do
+      it 'returns 401' do
+        post :create
+        expect(response.status).to eq(401)
+      end
+    end
 
-      body = JSON.parse(response.body)
-      expect(body['id']).to be_a(Integer)
+    context 'with regular user' do
+      let(:user) { create(:user) }
+      let(:token) { Knock::AuthToken.new(payload: { sub: user.id }).token }
+      let(:headers) { { 'Authorization': "Bearer #{token}" } }
+
+      it 'returns 401' do
+        post :create
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with admin user' do
+      let(:user) { create(:user, :admin) }
+      let(:token) { Knock::AuthToken.new(payload: { sub: user.id }).token }
+      let(:headers) { { 'Authorization': "Bearer #{token}" } }
+
+      before do
+        request.headers.merge! headers
+      end
+
+      it 'returns 201 and the resource category' do
+        post :create
+        expect(response.status).to eq(201)
+
+        body = JSON.parse(response.body)
+        expect(body['id']).to be_a(Integer)
+      end
     end
   end
 

--- a/spec/controllers/resource_steps_controller_spec.rb
+++ b/spec/controllers/resource_steps_controller_spec.rb
@@ -2,9 +2,12 @@ require 'rails_helper'
 require 'spec_helper'
 
 describe ResourceStepsController, type: :controller do
-  describe '#show' do
-    let(:id) { 1000 }
+  let(:token) { Knock::AuthToken.new(payload: { sub: user.id }).token }
+  let(:headers) { { 'Authorization': "Bearer #{token}" } }
 
+  let(:id) { 1000 }
+
+  describe '#show' do
     context 'where resource step exists' do
       before do
         resource_step = create(:resource_step, :with_resource, id: id)
@@ -34,125 +37,202 @@ describe ResourceStepsController, type: :controller do
 
     let(:params) { { resource_id: resource_id, number: number } }
 
-    context 'an invalid resource id' do
-      let(:resource_id) { 'fake-id' }
-
-      it 'returns 400 and an error' do
-        post :create, params: params
-        expect(response.status).to eq(400)
-        
-        body = JSON.parse(response.body)
-        expect(body['error']).to eq("Validation failed: Resource must exist")
+    context 'without authentication' do
+      it 'returns 401' do
+        post :create, params: { resource_id: '123' }
+        expect(response.status).to eq(401)
       end
     end
 
-    context 'without number' do
-      let(:number) { nil }
+    context 'with regular user' do
+      let(:user) { create(:user) }
 
-      it 'returns 400 and an error' do
-        post :create, params: params
-        expect(response.status).to eq(400)
-        
-        body = JSON.parse(response.body)
-        expect(body['error']).to eq("Missing number parameter")
+      it 'returns 401' do
+        post :create, params: { resource_id: '123' }
+        expect(response.status).to eq(401)
       end
     end
 
-    it 'returns 201 and the resource step' do
-      post :create, params: params
-      expect(response.status).to eq(201)
+    context 'with admin user' do
+      let(:user) { create(:user, :admin) }
 
-      body = JSON.parse(response.body)
-      expect(body['id']).to be_a(Integer)
-      expect(body['resource_id']).to eq(resource_id)
-      expect(body['number']).to eq(number)
+      before do
+        request.headers.merge! headers
+      end
+
+      context 'an invalid resource id' do
+        let(:resource_id) { 'fake-id' }
+
+        it 'returns 400 and an error' do
+          post :create, params: params
+          expect(response.status).to eq(400)
+          
+          body = JSON.parse(response.body)
+          expect(body['error']).to eq("Validation failed: Resource must exist")
+        end
+      end
+
+      context 'without number' do
+        let(:number) { nil }
+
+        it 'returns 400 and an error' do
+          post :create, params: params
+          expect(response.status).to eq(400)
+          
+          body = JSON.parse(response.body)
+          expect(body['error']).to eq("Missing number parameter")
+        end
+      end
+
+      it 'returns 201 and the resource step' do
+        post :create, params: params
+        expect(response.status).to eq(201)
+
+        body = JSON.parse(response.body)
+        expect(body['id']).to be_a(Integer)
+        expect(body['resource_id']).to eq(resource_id)
+        expect(body['number']).to eq(number)
+      end
     end
   end
 
   describe '#destroy' do
-    let(:id) { 1000 }
 
     before do
       resource_step = create(:resource_step, :with_resource, id: id)
     end
 
-    it 'returns 204 and an empty body' do
-      delete :destroy, params: { id: id }
-      expect(response.status).to eq(204)
-
-      body = JSON.parse(response.body)
-      expect(body).to be_empty
+    context 'without authentication' do
+      it 'returns 401' do
+        delete :destroy, params: { id: id }
+        expect(response.status).to eq(401)
+      end
     end
-  end
 
-  describe '#update' do
-    let(:id) { 1000 }
+    context 'with regular user' do
+      let(:user) { create(:user) }
 
-    context 'where resource step doesn\'t exist' do
-      it 'returns 404 and an empty body' do
-        put :update, params: { id: id }
-        expect(response.status).to eq(404)
+      before do
+        request.headers.merge! headers
+      end
+
+      it 'returns 401' do
+        delete :destroy, params: { id: id }
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with admin user' do
+      let(:user) { create(:user, :admin) }
+
+      before do
+        request.headers.merge! headers
+      end
+
+      it 'returns 204 and an empty body' do
+        delete :destroy, params: { id: id }
+        expect(response.status).to eq(204)
 
         body = JSON.parse(response.body)
         expect(body).to be_empty
       end
     end
+  end
 
-    context 'where resource step does exist' do
-      let!(:resource_step) { create(:resource_step, :with_resource, id: id) }
-      let!(:new_resource) { create(:resource, :with_resource_category) }
+  describe '#update' do
+    context 'with no authentication' do
+      it 'returns 401' do
+        put :update, params: { id: id }
+        expect(response.status).to eq(401)
+      end
+    end
 
-      context 'and update succeeds' do
-        let(:params) do
-          {
-            description: "resource step description",
-            number: 1,
-            resource_id: new_resource.id.to_i,
-          }
-        end
+    context 'with regular user' do
+      let(:user) { create(:user) }
+      
+      before do
+        request.headers.merge! headers
+      end
 
-        it 'returns 200 and new resource' do
-          put :update, params: params.merge({ id: id })
-          expect(response.status).to eq(200)
+      it 'returns 401' do
+        put :update, params: { id: id }
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with admin user' do
+      let(:user) { create(:user, :admin) }
+
+      before do
+        request.headers.merge! headers
+      end
+
+      context 'where resource step doesn\'t exist' do
+        it 'returns 404 and an empty body' do
+          put :update, params: { id: id }
+          expect(response.status).to eq(404)
 
           body = JSON.parse(response.body)
-          keys = %w(description number resource_id)
-
-          keys.each do |key|
-            expect(body[key]).to eq(params[key.to_sym])
-          end
+          expect(body).to be_empty
         end
+      end
 
-        context 'only altering one field' do
-          let(:new_description) { 'New resource step description' }
-          let(:old_number) { 1 }
-          let(:params) { { description: new_description } }
+      context 'where resource step does exist' do
+        let!(:resource_step) { create(:resource_step, :with_resource, id: id) }
+        let!(:new_resource) { create(:resource, :with_resource_category) }
 
-          before do
-            resource_step.number = old_number
-            resource_step.save!
+        context 'and update succeeds' do
+          let(:params) do
+            {
+              description: "resource step description",
+              number: 1,
+              resource_id: new_resource.id.to_i,
+            }
           end
 
-          it 'updates the fields passed into the params and does not modify anything else' do
+          it 'returns 200 and new resource' do
             put :update, params: params.merge({ id: id })
             expect(response.status).to eq(200)
 
             body = JSON.parse(response.body)
-            expect(body['description']).to eq(new_description)
-            expect(body['number']).to eq(old_number)
+            keys = %w(description number resource_id)
+
+            keys.each do |key|
+              expect(body[key]).to eq(params[key.to_sym])
+            end
           end
-        end
 
-        context 'with an invalid field' do
-          let(:new_number) { nil }
-          let(:params) { { number: new_number } }
+          context 'only altering one field' do
+            let(:new_description) { 'New resource step description' }
+            let(:old_number) { 1 }
+            let(:params) { { description: new_description } }
 
-          it 'returns 400 and an error message' do
-            put :update, params: params.merge({ id: id })
-            expect(response.status).to eq(400)
-            
-            body = JSON.parse(response.body)
-            expect(body['error']).to eq("Validation failed: Number can't be blank")
+            before do
+              resource_step.number = old_number
+              resource_step.save!
+            end
+
+            it 'updates the fields passed into the params and does not modify anything else' do
+              put :update, params: params.merge({ id: id })
+              expect(response.status).to eq(200)
+
+              body = JSON.parse(response.body)
+              expect(body['description']).to eq(new_description)
+              expect(body['number']).to eq(old_number)
+            end
+          end
+
+          context 'with an invalid field' do
+            let(:new_number) { nil }
+            let(:params) { { number: new_number } }
+
+            it 'returns 400 and an error message' do
+              put :update, params: params.merge({ id: id })
+              expect(response.status).to eq(400)
+              
+              body = JSON.parse(response.body)
+              expect(body['error']).to eq("Validation failed: Number can't be blank")
+            end
           end
         end
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :controller do
+
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,5 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe UsersController, type: :controller do
+  describe '#current' do
+    let(:email) { 'adalovelace@lovelace.net' }
+    let(:username) { 'ada' }
+    let(:role) { 'user' }
 
+    let(:user) { create(:user, email: email, username: username, role: role) }
+    let(:token) { Knock::AuthToken.new(payload: { sub: user.id }).token }
+
+    let(:headers) do
+      {
+        'Authorization': "Bearer #{token}"
+      }
+    end
+
+    context 'there is a logged in user' do
+      it 'returns 200 and the user information' do
+        request.headers.merge! headers
+        get :current
+        expect(response.status).to eq(200)
+
+        body = JSON.parse(response.body)
+        expect(body['id']).to be_a(Integer)
+        expect(body['email']).to eq(email)
+        expect(body['username']).to eq(username)
+        expect(body['role']).to eq(role)
+        expect(body['password_digest']).to be_nil
+      end
+    end
+
+    context 'there is no logged in user' do
+      it 'returns 401 and an empty body' do
+        get :current
+        expect(response.status).to eq(401)
+
+        body = JSON.parse(response.body)
+        expect(body).to be_empty
+      end
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :user do
+    email { 'example@example.com' }
+    username { 'example' }
     password { 'foobar123' }
 
     trait :admin do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :user do
-    
+    password { 'foobar123' }
+
+    trait :admin do
+      role { 'admin' }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
This PR adds a user model, as well as a JWT-based authentication and authorization scheme for the create, delete, and update endpoints using the [Knock](https://github.com/nsarno/knock) gem.

Here is my proposed user lifecycle:
1. **User creation:** I have NOT added any API endpoints for creating new users or updating their information. As far as I can tell, we will only need one or two users (the FreeFrom CMS admins), so I think that we should just go ahead and create those users in the database ourselves. Users have a `role` field, which either contains the string `user` or the string `admin`.

2. **Login:** A user authenticates by hitting the `POST /user_tokens` endpoint with the payload:
 ```
{
  "auth": {
    "email": "foo@bar.com",
    "password": "secret"
  }
}
```
If their authentication information is correct, they will get back a response like:
```
201 Created
{"jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"}
```

3. **Authentication:** The CMS can get information about the current user by hitting the `GET /users/current` endpoint with the JWT in the `Authorization` header -- `Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9`. This endpoint will return serialized information about the user in the format:
```
{
  "id": 3,
  "username": "freefrom-admin",
  "role": "admin"
}
```

3. **Authorization:** In order to successfully create, update, or destroy resources, the user will have to authenticate and authorize themselves. They can do this by passing in the following header to any of the POST, PUT, DELETE calls:
`{ "Authorization": "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9" }`

4. **Logout:** When a user logs out, the client can delete the JWT, forcing the user to log in before they can perform any operation requiring authorization. No server-side operation is necessary for logout. I've also given the JWTs an expiration time of 1 week, so the user will start getting back a 401 response on any of these endpoints and have to log in again.