### PR TITLE
Set Knock secret key in production

### DIFF
--- a/config/initializers/knock.rb
+++ b/config/initializers/knock.rb
@@ -36,7 +36,7 @@ Knock.setup do |config|
   ## Configure the key used to sign tokens.
   ##
   ## Default:
-  config.token_secret_signature_key = -> { Rails.application.secrets.secret_key_base }
+  config.token_secret_signature_key = -> { ENV['RAILS_ENV'] == 'production' ? ENV['SECRET_KEY_BASE'] : Rails.application.secrets.secret_key_base }
 
   ## If using Auth0, uncomment the line below
   # config.token_secret_signature_key = -> { JWT.base64url_decode Rails.application.secrets.auth0_client_secret }


### PR DESCRIPTION
Production is returning 500 on the `POST /user_tokens` endpoint. I suspect it's because of a missing environment variable (or rather that environment variable is not set on `Rails.application.secrets`), so I want to make sure prod gets it from the right place.

I don't think this is a good permanent solution, so I'll clean it up once we confirm that it's working.