### PR TITLE
Import script for quiz questions and mindset data

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - db/*/**
     - config/*/**
     - config/*
+    - lib/tasks/*
     - script/**
     - bin/**
     - spec/rails_helper.rb

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Run the command `gem install rails` (make sure `rails --version` returns 5.2.3)
 4. Run `rake db:setup` to create the test and development databases
 5. Run `rake db:migrate` to set up the necessary database tables
 6. Run `bundle exec rails s` to start the server
+7. Run `bundle exec rake import_data` to import seed data
 
 ## API Documentation
 ### Users and Authentication

--- a/data/mindsets.yml
+++ b/data/mindsets.yml
@@ -1,0 +1,8 @@
+- name: "The Reimbursement Boss"
+  description: "The Reimbursement Boss wants justice from their harm-doer, but also values their time and wants to move forward as quickly as possible. They feel confident telling their story and advocating for themselves in front of others. The name doesn’t lie, this person is an all-around Boss!"
+- name: "The Thoughtful Pursuer"
+  description: "The Thoughtful Pursuer values safety and wants to avoid risk if possible. They want to get money back without interacting with their harm-doer so they can move on with their life. Their priority is to get compensation while avoiding emotional stress. The Thoughtful Pursuer is an amazing advocate for their own health and healing!"
+- name: "The Justice Seeker"
+  description: "The Justice Seeker is driven to pursue justice even if it requires time, energy, and involves some risk. It is important to them that their harm-doer is held responsible for their actions. You definitely don’t want to get in the Justice Seeker’s way!"
+- name: "The Resourceful Strategist"
+  description: "The Resourceful Strategist wants to get compensation but has other things in their life that take priority. They don’t want to go through a process that will require a lot of their time and energy and would prefer to take a hands-off approach. The Resourceful Pursuer is all about working smarter, not harder!"

--- a/data/quiz_questions.yml
+++ b/data/quiz_questions.yml
@@ -1,0 +1,103 @@
+- title: "Your time"
+  description: "Some types of compensation are more time-consuming than others. Think about how much time you have to spend trying to get compensation and pick the statement below that best describes you."
+  responses:
+    - text: "I don’t have a lot of time to spare to try and get compensation (up to 8 hours)."
+      mindsets:
+        - "The Thoughtful Pursuer"
+    - text: "I have some time to spare to try and get compensation (8-20 hours)."
+      mindsets:
+        - "The Reimbursement Boss"
+        - "The Resourceful Strategist"
+    - text: I have a lot of time to spare to try and get compensation (over 20 hours).
+      mindsets:
+        - "The Justice Seeker"
+
+- title: "Timeframe"
+  description: "Some types of compensation take longer than others. Think about how urgently you need the money quickly you would need the money and pick the statement below that best describes you."
+  responses:
+    - text: "I need the money quickly (2-6 months)."
+      mindsets:
+        - "The Thoughtful Pursuer"
+        - "The Reimbursement Boss"
+    - text: "I don’t need the money right away (6 months – 1 year)."
+      mindsets:
+        - "The Resourceful Strategist"
+    - text: "I am able to wait a year or longer."
+      mindsets:
+        - "The Justice Seeker"
+
+- title: "Cost"
+  description: "Some types of compensation cost money to pursue, while others are free or low cost. Think about how much money you are willing/able to spend and pick the statement below that best describes you."
+  responses:
+    - text: "I need the money quickly (2-6 months)."
+      mindsets:
+        - "The Thoughtful Pursuer"
+        - "The Resourceful Strategist"
+    - text: "I can afford to pay some fees ($50 -$200)."
+      mindsets:
+        - "The Resourceful Strategist"
+    - text: "I can afford to pay a lawyer (over $1,000)."
+      mindsets:
+        - "The Justice Seeker"
+
+- title: "Award"
+  description: "Different types of compensation will pay out different amounts of money for different types of costs. Think about what you need compensation for and pick the statement below that best describes you."
+  responses:
+    - text: "I need compensation to cover costs, including damaged property (for example, a broken laptop), that are less than $10,000 in total."
+      mindsets:
+        - "The Reimbursement Boss"
+        - "The Resourceful Strategist"
+    - text: "I need compensation to cover costs, not including damaged property, that are less than $10,000 in total."
+      mindsets:
+        - "The Reimbursement Boss"
+        - "The Resourceful Strategist"
+        - "The Thoughtful Pursuer"
+    - text: "I need compensation to cover costs, including damaged property, that are more than $10,000 in total."
+      mindsets:
+        - "The Justice Seeker"
+        - "The Resourceful Strategist"
+    - text: "I need compensation to cover costs, not including damaged property, that are more than $10,000 in total."
+      mindsets:
+        - "The Justice Seeker"
+        - "The Thoughtful Pursuer"
+        - "The Resourceful Strategist"
+
+- title: "Risk"
+  description: "Some types of compensation are more likely to award money than others. Think about how comfortable you are with taking a risk in this process and pick the statement below that best describes you."
+  responses:
+    - text: "I am willing to take a risk if it means I may be able to get more money."
+      mindsets:
+        - "The Justice Seeker"
+        - "The Reimbursement Boss"
+    - text: "I would rather go with an option that is less risky, even if it means I might get less money."
+      mindsets:
+        - "The Resourceful Strategist"
+        - "The Thoughtful Pursuer"
+
+- title: "Safety"
+  description: "Some types of compensation may require you to go to court and be in the same room as your harm-doer. Pick the statement below that is true for you."
+  responses:
+    - text: "I do not want to be in the same room as my harm-doer."
+      mindsets:
+        - "The Thoughtful Pursuer"
+    - text: "I could be in the same room as my harm-doer if I had an attorney or a support person with me."
+      mindsets:
+        - "The Justice Seeker"
+        - "The Resourceful Strategist"
+    - text: "I could be in the same room as my harm-doer without an attorney or support person with me."
+      mindsets:
+        - "The Reimbursement Boss"
+
+- title: "Story"
+  description: "Some types of compensation require you to tell your story multiple times. Think about whether you feel ok retelling your story and pick the statement below that best describes you."
+  responses:
+    - text: "I am willing to talk to anyone about my story, even without someone there to support me."
+      mindsets:
+        - "The Justice Seeker"
+    - text: "I am willing to talk about my story as long as I am supported by trauma-informed professionals (trained lawyers or other advocates)."
+      mindsets:
+        - "The Thoughtful Pursuer"
+        - "The Resourceful Strategist"
+    - text: "I am willing to talk to anyone about my story, as long as a family member or friend is there to support me."
+      mindsets:
+        - "The Reimbursement Boss"

--- a/lib/tasks/import_data.rake
+++ b/lib/tasks/import_data.rake
@@ -1,0 +1,41 @@
+task :import_data => :environment do
+  require 'yaml'
+
+  # Always destroy data before re-importing
+  ResourceCategory.destroy_all
+  Mindset.destroy_all
+  QuizQuestion.destroy_all
+  QuizResponse.destroy_all
+
+  # This is just to create the quiz questions below
+  ResourceCategory.create(id: 1)
+
+  mindsets = YAML.load(File.read('data/mindsets.yml'))
+  mindset_name_to_id = {} # Create a convenient way of associating mindset names with ids
+
+  mindsets.each do |mindset|
+    mindset_obj = Mindset.create(
+      name: mindset['name'],
+      description: mindset['description'],
+      resource_category_id: 1
+    )
+
+    mindset_name_to_id[mindset['name']] = mindset_obj.id
+  end
+
+  quiz_questions = YAML.load(File.read('data/quiz_questions.yml'))
+  quiz_questions.each do |question|
+    question_obj = QuizQuestion.create(
+      title: question['title'],
+      description: question['description']
+    )
+
+    question['responses'].each do |response|
+      QuizResponse.create(
+        quiz_question_id: question_obj.id,
+        text: response['text'],
+        mindset_ids: response['mindsets'].map { |name| mindset_name_to_id[name] }
+      )
+    end
+  end
+end


### PR DESCRIPTION
I have written a Rake task that will import seed data into the database based on yml files that I have created in the `/data` folder. There are instructions for running the script in `README.md`.

Thus far, the script only imports questions and mindset data in order to unblock work on the quiz questions and results. I will create a follow-up PR to import some sample data for resource categories and resources.

This rake task does not yet have any automated testing, but I want to get it out quickly to unblock people. I will include tests in the follow-up.

Related to issue #32 