### PR TITLE
Add `rake import_data` to setup steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Run the command `gem install rails` (make sure `rails --version` returns 5.2.3)
 3. Run `bundle install` to install the app's dependencies (run `gem install bundler` if that doesn't work)
 4. Run `rake db:setup` to create the test and development databases
 5. Run `rake db:migrate` to set up the necessary database tables
-6. Run `bundle exec rails s` to start the server
+6. Run `bundle exec rake import_data` to import the seed data
+7. Run `bundle exec rails s` to start the server
 
 ## API Documentation
 


### PR DESCRIPTION
I thought it might be good to add `bundle exec rake import_data` to the setup instructions since I get front-end errors unless I run that command. Let me know if this is just me, or feel free to edit the wording in README since I barely know anything about Rails or databases