### PR TITLE
Add How to Guide and Report an Issue links in sidebar

### DIFF
--- a/app/views/admin/application/_navigation.html.erb
+++ b/app/views/admin/application/_navigation.html.erb
@@ -20,13 +20,15 @@ as defined by the routes in the `admin/` namespace
       "How to Guide",
       "https://docs.google.com/document/d/1k-wuzuIhrNMjt6YjdRpzjdbMcRK7nnwuUsujQQaOM80/edit#heading=h.f97lq7p5makl",
       class: "navigation__link",
-      target: :_blank
+      target: :_blank,
+      rel: "noopener noreferrer"
   ) %>
   <%= link_to(
       "Report an Issue",
       "https://github.com/RagtagOpen/freefrom-compensation-api/issues",
       class: "navigation__link",
-      target: :_blank
+      target: :_blank,
+      rel: "noopener noreferrer"
   ) %>
   <%= link_to(
       "Logout",

--- a/app/views/admin/application/_navigation.html.erb
+++ b/app/views/admin/application/_navigation.html.erb
@@ -15,6 +15,19 @@ as defined by the routes in the `admin/` namespace
       class: "navigation__link navigation__link--#{nav_link_state(resource)}"
     ) %>
   <% end %>
+  <hr />
+  <%= link_to(
+      "How to Guide",
+      "https://docs.google.com/document/d/1k-wuzuIhrNMjt6YjdRpzjdbMcRK7nnwuUsujQQaOM80/edit#heading=h.f97lq7p5makl",
+      class: "navigation__link",
+      target: :_blank
+  ) %>
+  <%= link_to(
+      "Report an Issue",
+      "https://github.com/RagtagOpen/freefrom-compensation-api/issues",
+      class: "navigation__link",
+      target: :_blank
+  ) %>
   <%= link_to(
       "Logout",
       destroy_user_session_path,


### PR DESCRIPTION
Fixes #74 and #75.

I promised our friends at FreeFrom that I would add a link to my How to Guide and the GitHub issue page to the CMS sidebar.

<img width="1440" alt="Screen Shot 2020-07-11 at 5 11 35 PM" src="https://user-images.githubusercontent.com/9601737/87233889-970f5b00-c399-11ea-8cd9-bd20c861c2e3.png">
